### PR TITLE
Added static LastNode

### DIFF
--- a/Chronometer/Classes/ScriptProfiler.ps1
+++ b/Chronometer/Classes/ScriptProfiler.ps1
@@ -3,6 +3,8 @@ class ScriptProfiler {
     static [System.Collections.Queue] $Queue
     static [System.Diagnostics.Stopwatch] $Timer
 
+    static $LastNode = $null
+
     static [void] Start()
     {
         [ScriptProfiler]::Queue = New-Object System.Collections.Queue
@@ -15,5 +17,7 @@ class ScriptProfiler {
             Breakpoint = $InputObject
             Elapsed = [ScriptProfiler]::Timer.Elapsed
         })
+
+        [ScriptProfiler]::LastNode = $InputObject
     }
 }


### PR DESCRIPTION
The LastNode is used with the changes to Get-Chronometer to properly calculated data for the last line in the file. For example the following script's last line will not get any timing information because of a last record bug in the existing code:

Start-Sleep 5
Start-Sleep 10